### PR TITLE
Change to reflect CCP security changes

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -715,10 +715,7 @@ namespace ISBoxerEVELauncher
       private void ApplicationStart(object sender, StartupEventArgs e)
       {
          AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
-         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls
-                  | SecurityProtocolType.Tls11
-                  | SecurityProtocolType.Tls12
-                  | SecurityProtocolType.Ssl3;
+         ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls13;
 
          CommandLine = e.Args;
 


### PR DESCRIPTION
CCP dropped all support for connections less than TLS 1.3
Not in a position to personally test this so YMMV, and SSL may still work - If nothing else treat this PR as notification of the breaking change.

Addresses #41