### PR TITLE
Fix EVE login and refresh tokens

### DIFF
--- a/ChangeHistory.txt
+++ b/ChangeHistory.txt
@@ -1,4 +1,6 @@
 ﻿
+* Unreleased Fix login flow for current EVE SSO behavior. Added OAuth2 refresh token support, refresh-token import from the official EVE Launcher, a WebView2 manual login fallback, per-account credential state indicators, right-click Set Password, Clear OAuth2 Refresh Tokens, and debug logging for login troubleshooting. WebView2 loader checks now report a clear packaging error, and WebView2 data is isolated per account.
+
 * Version 1.0.0.41 Merge back to Master from multi branch tree
 
 * Version 1.0.0.40 Added DX12 support, added refreshToken to the authentication process, removed x64 option (this is now the default)

--- a/Extensions/StringExtension.cs
+++ b/Extensions/StringExtension.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security;
 
 namespace ISBoxerEVELauncher.Extensions
 {
@@ -116,6 +117,20 @@ namespace ISBoxerEVELauncher.Extensions
         public static string SHA256(this string plaintext)
         {
             return ISBoxerEVELauncher.Security.SHA256.GenerateString(plaintext);
+        }
+        
+        public static SecureString ToSecureString(this string str)
+        {
+            if (str == null)
+                throw new ArgumentNullException("str");
+
+            var secureStr = new SecureString();
+            foreach (char c in str)
+            {
+                secureStr.AppendChar(c);
+            }
+            secureStr.MakeReadOnly();
+            return secureStr;
         }
     }
 }

--- a/Games/EVE/EVEAccount.cs
+++ b/Games/EVE/EVEAccount.cs
@@ -228,20 +228,19 @@ namespace ISBoxerEVELauncher.Games.EVE
             }
         }
 
-        string _WebView2CookieStorage;
         /// <summary>
         /// WebView2 cookie storage (JSON format) - separate from HttpWebRequest cookies
         /// </summary>
+        [XmlIgnore]
         public string WebView2CookieStorage
         {
             get
             {
-                return _WebView2CookieStorage;
+                return ISBoxerEVELauncher.Web.CookieStorage.GetWebViewCookies(this);
             }
             set
             {
-                _WebView2CookieStorage = value;
-                OnPropertyChanged("WebView2CookieStorage");
+                ISBoxerEVELauncher.Web.CookieStorage.SetWebViewCookies(this, value);
             }
         }
 
@@ -1449,6 +1448,7 @@ namespace ISBoxerEVELauncher.Games.EVE
             this.EncryptedCharacterNameIV = null;
 
             ISBoxerEVELauncher.Web.CookieStorage.DeleteCookies(this);
+            ISBoxerEVELauncher.Web.CookieStorage.DeleteWebViewCookies(this);
             this.Username = null;
             this.Cookies = null;
             //this.NewCookieStorage = null;

--- a/Games/EVE/EVEAccount.cs
+++ b/Games/EVE/EVEAccount.cs
@@ -42,20 +42,43 @@ namespace ISBoxerEVELauncher.Games.EVE
         [XmlIgnore]
         private string code;
 
-        public string Profile
-        {
-            get; set;
-        }
-
-
         public EVEAccount()
         {
             state = Guid.NewGuid();
             challengeCodeSource = Guid.NewGuid();
             challengeCode = Encoding.UTF8.GetBytes(challengeCodeSource.ToString().Replace("-", ""));
             challengeHash = Base64UrlEncoder.Encode(ISBoxerEVELauncher.Security.SHA256.GenerateHash(Base64UrlEncoder.Encode(challengeCode)));
-            Profile = "Default";
         }
+
+        public class CredentialBadge
+        {
+            public string Glyph { get; set; }
+            public System.Windows.Media.Brush Brush { get; set; }
+            public string Tooltip { get; set; }
+        }
+
+        private void OnCredentialChanged()
+        {
+            OnPropertyChanged("Credential");
+        }
+
+        [XmlIgnore]
+        public CredentialBadge Credential
+        {
+            get
+            {
+                bool hasPassword = !string.IsNullOrEmpty(EncryptedPassword);
+                bool hasToken = !string.IsNullOrEmpty(EncryptedTranquilityRefreshToken);
+                if (hasPassword && hasToken)
+                    return new CredentialBadge { Glyph = "", Brush = System.Windows.Media.Brushes.ForestGreen, Tooltip = "Password and refresh token stored" };
+                if (hasPassword)
+                    return new CredentialBadge { Glyph = "", Brush = System.Windows.Media.Brushes.Goldenrod, Tooltip = "Password stored" };
+                if (hasToken)
+                    return new CredentialBadge { Glyph = "", Brush = System.Windows.Media.Brushes.DodgerBlue, Tooltip = "Refresh token stored" };
+                return new CredentialBadge { Glyph = string.Empty, Brush = System.Windows.Media.Brushes.Transparent, Tooltip = "No credentials stored" };
+            }
+        }
+
 
 
 
@@ -281,6 +304,7 @@ namespace ISBoxerEVELauncher.Games.EVE
             {
                 _EncryptedPassword = value;
                 OnPropertyChanged("EncryptedPassword");
+                OnCredentialChanged();
             }
         }
 
@@ -693,6 +717,7 @@ namespace ISBoxerEVELauncher.Games.EVE
             {
                 _encryptedTranquilityRefreshToken = value;
                 OnPropertyChanged("EncryptedTranquilityRefreshToken");
+                OnCredentialChanged();
             }
         }
         

--- a/Games/EVE/EVEAccount.cs
+++ b/Games/EVE/EVEAccount.cs
@@ -1682,7 +1682,16 @@ namespace ISBoxerEVELauncher.Games.EVE
                 return LoginResult.Success;
             }
 
-            // need SecurePassword.
+            // Try refresh token before asking for a password. If we have a working refresh token
+            // (e.g. imported from the official EVE Launcher) we should never need credentials.
+            Utils.Debug.Info($"GetAccessToken - Attempting refresh token login", LogCategory);
+            if (TryGetFromRefreshToken(sisi, out accessToken))
+            {
+                Utils.Debug.Info($"GetAccessToken - Refresh token login successful", LogCategory);
+                return LoginResult.Success;
+            }
+
+            // Refresh token unavailable or rejected; fall back to password (decrypt or prompt).
             Utils.Debug.Info($"GetAccessToken - Checking for SecurePassword", LogCategory);
             if (SecurePassword == null || SecurePassword.Length == 0)
             {
@@ -1707,10 +1716,11 @@ namespace ISBoxerEVELauncher.Games.EVE
                 }
             }
 
-            Utils.Debug.Info($"GetAccessToken - Attempting refresh token login", LogCategory);
+            // Retry refresh token after credentials/master password may have been provided above.
+            Utils.Debug.Info($"GetAccessToken - Retrying refresh token login after password step", LogCategory);
             if (TryGetFromRefreshToken(sisi, out accessToken))
             {
-                Utils.Debug.Info($"GetAccessToken - Refresh token login successful", LogCategory);
+                Utils.Debug.Info($"GetAccessToken - Refresh token login successful (post-password)", LogCategory);
                 return LoginResult.Success;
             }
 
@@ -1759,12 +1769,12 @@ namespace ISBoxerEVELauncher.Games.EVE
             }
 
             Utils.Debug.Info($"GetAccessToken - Got verification token, creating login POST request", LogCategory);
-            var req = RequestResponse.CreatePostRequest(uri, sisi, true, "URL", Cookies);
+            var postUri = RequestResponse.GetLoginPostUri(sisi, state.ToString(), challengeHash);
+            var req = RequestResponse.CreatePostRequest(postUri, sisi, true, "URL", Cookies);
 
             using (SecureBytesWrapper body = new SecureBytesWrapper())
             {
-                byte[] body1 = Encoding.ASCII.GetBytes(String.Format("__RequestVerificationToken={1}&UserName={0}&Password=", Uri.EscapeDataString(Username), Uri.EscapeDataString(RequestVerificationToken)));
-                //                byte[] body1 = Encoding.ASCII.GetBytes(String.Format("UserName={0}&Password=", Uri.EscapeDataString(Username)));
+                byte[] body1 = Encoding.ASCII.GetBytes(String.Format("ClientIdentifier=eveLauncherTQ&__RequestVerificationToken={1}&UserName={0}&Password=", Uri.EscapeDataString(Username), Uri.EscapeDataString(RequestVerificationToken)));
                 using (SecureStringWrapper ssw = new SecureStringWrapper(SecurePassword, Encoding.ASCII))
                 {
                     using (SecureBytesWrapper escapedPassword = new SecureBytesWrapper())

--- a/Games/EVE/EVEAccount.cs
+++ b/Games/EVE/EVEAccount.cs
@@ -339,7 +339,7 @@ namespace ISBoxerEVELauncher.Games.EVE
 
             if (!App.Settings.RequestMasterPassword())
             {
-                System.Windows.MessageBox.Show("Your configured Master Password is required in order to save EVE Account passwords. It can be reset or disabled by un-checking 'Save passwords (securely)', and then all currently saved EVE Account passwords will be lost.");
+                System.Windows.MessageBox.Show("Your configured Master Password is required in order to save EVE Account passwords. It can be reset or disabled by un-checking 'Save credentials (securely)', and then all currently saved EVE Account passwords will be lost.");
                 return;
             }
 
@@ -553,7 +553,7 @@ namespace ISBoxerEVELauncher.Games.EVE
 
             if (!App.Settings.RequestMasterPassword())
             {
-                System.Windows.MessageBox.Show("Your configured Master Password is required in order to save EVE Account Character Names and passwords. It can be reset or disabled by un-checking 'Save passwords (securely)', and then all currently saved EVE Account Character Names will be lost.");
+                System.Windows.MessageBox.Show("Your configured Master Password is required in order to save EVE Account Character Names and passwords. It can be reset or disabled by un-checking 'Save credentials (securely)', and then all currently saved EVE Account Character Names will be lost.");
                 return;
             }
 
@@ -863,7 +863,7 @@ namespace ISBoxerEVELauncher.Games.EVE
 
             if (!App.Settings.RequestMasterPassword())
             {
-                System.Windows.MessageBox.Show("Your configured Master Password is required in order to save refresh tokens. It can be reset or disabled by un-checking 'Save passwords (securely)', and then all currently saved refresh tokens will be lost.");
+                System.Windows.MessageBox.Show("Your configured Master Password is required in order to save refresh tokens. It can be reset or disabled by un-checking 'Save credentials (securely)', and then all currently saved refresh tokens will be lost.");
                 return;
             }
 
@@ -982,7 +982,7 @@ namespace ISBoxerEVELauncher.Games.EVE
 
             if (!App.Settings.RequestMasterPassword())
             {
-                System.Windows.MessageBox.Show("Your configured Master Password is required in order to save refresh tokens. It can be reset or disabled by un-checking 'Save passwords (securely)', and then all currently saved refresh tokens will be lost.");
+                System.Windows.MessageBox.Show("Your configured Master Password is required in order to save refresh tokens. It can be reset or disabled by un-checking 'Save credentials (securely)', and then all currently saved refresh tokens will be lost.");
                 return;
             }
 

--- a/Games/EVE/EVELauncherStateReader.cs
+++ b/Games/EVE/EVELauncherStateReader.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Nodes;
+
+namespace ISBoxerEVELauncher.Games.EVE
+{
+    public class ImportCandidate
+    {
+        public long UserId { get; set; }
+        public string Username { get; set; }
+        public string RefreshToken { get; set; }
+        public bool IsActive { get; set; }
+    }
+
+    public static class EVELauncherStateReader
+    {
+        private const string ExpectedClientId = "eveLauncherTQ";
+        private const string DpapiPrefix = "DPAPI";
+        private const int GcmNonceSize = 12;
+        private const int GcmTagSize = 16;
+        private const int ChromiumHeaderSize = 3;
+
+        private static string GetEvePath()
+        {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "EVE Online");
+        }
+
+        private static string GetLocalStatePath()
+        {
+            return Path.Combine(GetEvePath(), "Local State");
+        }
+
+        private static string GetStateJsonPath()
+        {
+            return Path.Combine(GetEvePath(), "state.json");
+        }
+
+        public static bool StateFileExists()
+        {
+            return File.Exists(GetLocalStatePath()) && File.Exists(GetStateJsonPath());
+        }
+
+        public static List<ImportCandidate> Read()
+        {
+            byte[] key = UnwrapMasterKey(File.ReadAllText(GetLocalStatePath()));
+            string decrypted = DecryptStateJson(File.ReadAllText(GetStateJsonPath()), key);
+            return ParseCandidates(decrypted);
+        }
+
+        private static byte[] UnwrapMasterKey(string localStateJson)
+        {
+            JsonNode root = JsonNode.Parse(localStateJson);
+            string encoded = root?["os_crypt"]?["encrypted_key"]?.GetValue<string>();
+            if (string.IsNullOrEmpty(encoded))
+                throw new InvalidDataException("EVE Launcher Local State is missing os_crypt.encrypted_key.");
+
+            byte[] wrapped = Convert.FromBase64String(encoded);
+            byte[] prefix = Encoding.ASCII.GetBytes(DpapiPrefix);
+            if (wrapped.Length <= prefix.Length)
+                throw new InvalidDataException("EVE Launcher Local State encrypted_key is too short.");
+            for (int i = 0; i < prefix.Length; i++)
+            {
+                if (wrapped[i] != prefix[i])
+                    throw new InvalidDataException("EVE Launcher Local State encrypted_key does not start with the expected DPAPI prefix.");
+            }
+
+            byte[] blob = new byte[wrapped.Length - prefix.Length];
+            Buffer.BlockCopy(wrapped, prefix.Length, blob, 0, blob.Length);
+            return ProtectedData.Unprotect(blob, null, DataProtectionScope.CurrentUser);
+        }
+
+        private static string DecryptStateJson(string stateJsonText, byte[] key)
+        {
+            JsonNode root = JsonNode.Parse(stateJsonText);
+            string encoded = root?["state"]?.GetValue<string>();
+            if (string.IsNullOrEmpty(encoded))
+                throw new InvalidDataException("EVE Launcher state.json is missing the encrypted state field.");
+
+            byte[] blob = Convert.FromBase64String(encoded);
+            if (blob.Length < ChromiumHeaderSize + GcmNonceSize + GcmTagSize)
+                throw new InvalidDataException("EVE Launcher state.json encrypted payload is too short.");
+
+            byte[] nonce = new byte[GcmNonceSize];
+            Buffer.BlockCopy(blob, ChromiumHeaderSize, nonce, 0, GcmNonceSize);
+
+            int cipherStart = ChromiumHeaderSize + GcmNonceSize;
+            int cipherLen = blob.Length - cipherStart - GcmTagSize;
+            byte[] ciphertext = new byte[cipherLen];
+            Buffer.BlockCopy(blob, cipherStart, ciphertext, 0, cipherLen);
+
+            byte[] tag = new byte[GcmTagSize];
+            Buffer.BlockCopy(blob, blob.Length - GcmTagSize, tag, 0, GcmTagSize);
+
+            byte[] plaintext = BCryptAesGcm.Decrypt(key, nonce, ciphertext, tag);
+            return Encoding.UTF8.GetString(plaintext);
+        }
+
+        private static List<ImportCandidate> ParseCandidates(string decryptedStateJson)
+        {
+            var result = new List<ImportCandidate>();
+            JsonNode root = JsonNode.Parse(decryptedStateJson);
+            JsonNode tq = root?["v2.1/users"]?["eve-online"]?["tranquility"];
+            if (tq == null) return result;
+
+            long? activeUserId = null;
+            JsonNode activeNode = tq["activeUserId"];
+            if (activeNode != null)
+            {
+                try { activeUserId = activeNode.GetValue<long>(); } catch { }
+            }
+
+            JsonArray ids = tq["ids"] as JsonArray;
+            JsonNode entities = tq["entities"];
+            if (ids == null || entities == null) return result;
+
+            foreach (JsonNode idNode in ids)
+            {
+                if (idNode == null) continue;
+                long userId;
+                try { userId = idNode.GetValue<long>(); } catch { continue; }
+
+                JsonNode entity = entities[userId.ToString()];
+                if (entity == null) continue;
+
+                JsonNode tokens = entity["tokens"];
+                string refreshToken = tokens?["refreshToken"]?.GetValue<string>();
+                string clientId = tokens?["clientId"]?.GetValue<string>();
+                if (string.IsNullOrEmpty(refreshToken)) continue;
+                if (!string.Equals(clientId, ExpectedClientId, StringComparison.Ordinal)) continue;
+
+                string name = entity["name"]?.GetValue<string>();
+                if (string.IsNullOrEmpty(name)) continue;
+
+                result.Add(new ImportCandidate
+                {
+                    UserId = userId,
+                    Username = name,
+                    RefreshToken = refreshToken,
+                    IsActive = activeUserId.HasValue && activeUserId.Value == userId,
+                });
+            }
+
+            return result;
+        }
+
+        private static class BCryptAesGcm
+        {
+            private const string Bcrypt = "bcrypt.dll";
+            private const string AES_ALGORITHM = "AES";
+            private const string GCM_CHAIN_MODE = "ChainingModeGCM";
+            private const string PROP_CHAINING_MODE = "ChainingMode";
+            private const string PROP_OBJECT_LENGTH = "ObjectLength";
+            private const uint STATUS_SUCCESS = 0;
+            private const uint STATUS_AUTH_TAG_MISMATCH = 0xC000A002;
+
+            [DllImport(Bcrypt, CharSet = CharSet.Unicode)]
+            private static extern uint BCryptOpenAlgorithmProvider(out IntPtr phAlgorithm, string pszAlgId, string pszImplementation, uint dwFlags);
+
+            [DllImport(Bcrypt)]
+            private static extern uint BCryptCloseAlgorithmProvider(IntPtr hAlgorithm, uint dwFlags);
+
+            [DllImport(Bcrypt, CharSet = CharSet.Unicode)]
+            private static extern uint BCryptSetProperty(IntPtr hObject, string pszProperty, byte[] pbInput, int cbInput, uint dwFlags);
+
+            [DllImport(Bcrypt, CharSet = CharSet.Unicode)]
+            private static extern uint BCryptGetProperty(IntPtr hObject, string pszProperty, byte[] pbOutput, int cbOutput, out int pcbResult, uint dwFlags);
+
+            [DllImport(Bcrypt)]
+            private static extern uint BCryptGenerateSymmetricKey(IntPtr hAlgorithm, out IntPtr phKey, byte[] pbKeyObject, int cbKeyObject, byte[] pbSecret, int cbSecret, uint dwFlags);
+
+            [DllImport(Bcrypt)]
+            private static extern uint BCryptDestroyKey(IntPtr hKey);
+
+            [DllImport(Bcrypt)]
+            private static extern uint BCryptDecrypt(
+                IntPtr hKey,
+                byte[] pbInput, int cbInput,
+                ref BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO pAuthInfo,
+                byte[] pbIV, int cbIV,
+                byte[] pbOutput, int cbOutput,
+                out int pcbResult, uint dwFlags);
+
+            [StructLayout(LayoutKind.Sequential)]
+            private struct BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO
+            {
+                public int cbSize;
+                public int dwInfoVersion;
+                public IntPtr pbNonce;
+                public int cbNonce;
+                public IntPtr pbAuthData;
+                public int cbAuthData;
+                public IntPtr pbTag;
+                public int cbTag;
+                public IntPtr pbMacContext;
+                public int cbMacContext;
+                public int cbAAD;
+                public long cbData;
+                public int dwFlags;
+            }
+
+            public static byte[] Decrypt(byte[] key, byte[] nonce, byte[] ciphertext, byte[] tag)
+            {
+                IntPtr hAlg = IntPtr.Zero;
+                IntPtr hKey = IntPtr.Zero;
+                GCHandle nonceHandle = default(GCHandle);
+                GCHandle tagHandle = default(GCHandle);
+                try
+                {
+                    uint status = BCryptOpenAlgorithmProvider(out hAlg, AES_ALGORITHM, null, 0);
+                    if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptOpenAlgorithmProvider failed: 0x" + status.ToString("X8"));
+
+                    byte[] gcmBytes = Encoding.Unicode.GetBytes(GCM_CHAIN_MODE + "\0");
+                    status = BCryptSetProperty(hAlg, PROP_CHAINING_MODE, gcmBytes, gcmBytes.Length, 0);
+                    if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptSetProperty(ChainingMode) failed: 0x" + status.ToString("X8"));
+
+                    byte[] objLenBytes = new byte[4];
+                    int got;
+                    status = BCryptGetProperty(hAlg, PROP_OBJECT_LENGTH, objLenBytes, objLenBytes.Length, out got, 0);
+                    if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptGetProperty(ObjectLength) failed: 0x" + status.ToString("X8"));
+                    int objLen = BitConverter.ToInt32(objLenBytes, 0);
+
+                    byte[] keyObject = new byte[objLen];
+                    status = BCryptGenerateSymmetricKey(hAlg, out hKey, keyObject, objLen, key, key.Length, 0);
+                    if (status != STATUS_SUCCESS) throw new CryptographicException("BCryptGenerateSymmetricKey failed: 0x" + status.ToString("X8"));
+
+                    nonceHandle = GCHandle.Alloc(nonce, GCHandleType.Pinned);
+                    tagHandle = GCHandle.Alloc(tag, GCHandleType.Pinned);
+
+                    var info = new BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO();
+                    info.cbSize = Marshal.SizeOf(typeof(BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO));
+                    info.dwInfoVersion = 1;
+                    info.pbNonce = nonceHandle.AddrOfPinnedObject();
+                    info.cbNonce = nonce.Length;
+                    info.pbTag = tagHandle.AddrOfPinnedObject();
+                    info.cbTag = tag.Length;
+
+                    byte[] plaintext = new byte[ciphertext.Length];
+                    int written;
+                    status = BCryptDecrypt(hKey, ciphertext, ciphertext.Length, ref info, null, 0, plaintext, plaintext.Length, out written, 0);
+                    if (status == STATUS_AUTH_TAG_MISMATCH)
+                        throw new CryptographicException("EVE Launcher state failed AES-GCM authentication. The file may be corrupted.");
+                    if (status != STATUS_SUCCESS)
+                        throw new CryptographicException("BCryptDecrypt failed: 0x" + status.ToString("X8"));
+
+                    if (written != plaintext.Length)
+                    {
+                        byte[] trimmed = new byte[written];
+                        Buffer.BlockCopy(plaintext, 0, trimmed, 0, written);
+                        return trimmed;
+                    }
+                    return plaintext;
+                }
+                finally
+                {
+                    if (nonceHandle.IsAllocated) nonceHandle.Free();
+                    if (tagHandle.IsAllocated) tagHandle.Free();
+                    if (hKey != IntPtr.Zero) BCryptDestroyKey(hKey);
+                    if (hAlg != IntPtr.Zero) BCryptCloseAlgorithmProvider(hAlg, 0);
+                }
+            }
+        }
+    }
+}

--- a/ISBoxerEVELauncher.csproj
+++ b/ISBoxerEVELauncher.csproj
@@ -341,6 +341,7 @@
     <Compile Include="Web\BrowserCookie.cs" />
     <Compile Include="Web\CookieStorage.cs" />
     <Compile Include="Games\EVE\EVECharacter.cs" />
+    <Compile Include="Games\EVE\EVELauncherStateReader.cs" />
     <Compile Include="Extensions\HttpWebResponseExtension.cs" />
     <Compile Include="Extensions\ProcessExtension.cs" />
     <Compile Include="Extensions\UriExtension.cs" />
@@ -375,6 +376,9 @@
     </Compile>
     <Compile Include="Windows\EVEEULAWindow.xaml.cs">
       <DependentUpon>EVEEULAWindow.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Windows\ImportFromEVELauncherWindow.xaml.cs">
+      <DependentUpon>ImportFromEVELauncherWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="InnerSpace\InnerSpaceGameProfile.cs" />
     <Compile Include="Windows\EVELoginBrowser.cs">
@@ -435,6 +439,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Windows\EVELogin.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Windows\ImportFromEVELauncherWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ![Screenshot](http://i.imgur.com/fe1Y7cl.png)
 # Recent changes
 
+* Unreleased Fixes the EVE login flow for current SSO behavior, adds OAuth2 refresh token login, imports refresh tokens from the official EVE Launcher, adds a WebView2 manual login fallback, and shows stored credential state per account.
+
 * Version 1.0.0.42 Merged some important pull requests
 
 
@@ -17,6 +19,11 @@ If password storage is enabled, ISBoxer EVE Launcher keeps your EVE passwords cr
 # Installation
 Un-zip the ISBoxer EVE Launcher.exe file into the location of your choice. If intending to use with Inner Space/ISBoxer, it is recommended to place the file in the Inner Space folder.
 
+The manual login flow uses Microsoft WebView2. When installing from a zip file, keep the included **runtimes** folder next to ISBoxerEVELauncher.exe. If WebView2Loader.dll is missing, manual login will show an error asking for one of these files:
+
+* **runtimes\win-x86\native\WebView2Loader.dll**
+* **runtimes\win-x64\native\WebView2Loader.dll**
+
 An XML settings file will be placed in the same location, *making the launcher Portable*, but also meaning that Administrator permissions will be required if this is placed under the Program Files folder.
 
 # Usage
@@ -32,14 +39,48 @@ When you first run ISBoxer EVE Launcher, it may need to be told where the EVE Sh
 ## Adding EVE Accounts
 To add an EVE Account to ISBoxer EVE Launcher, click Add Account. A window pops up asking for your EVE login details. Enter your EVE username and password. Your EVE Account password is kept secure, and will not be saved in the settings file by default.
 
-## Saving EVE Account passwords
+ISBoxer EVE Launcher can now log in with OAuth2 refresh tokens. When **Use OAuth2 Refresh Tokens** is enabled, a successful login stores an encrypted refresh token and future launches can usually authenticate without re-entering the EVE account password.
+
+The account list shows a credential indicator next to each account:
+
+* Green: password and refresh token are stored
+* Yellow: password is stored
+* Blue: refresh token is stored
+* Blank: no stored credentials
+
+Right-click an account and choose **Set Password...** to update its saved password without re-adding the account. Use **Clear OAuth2 Refresh Tokens** to clear stored refresh tokens for the selected accounts; those accounts will need to authenticate again on the next launch.
+
+## Importing From EVE Launcher
+ISBoxer EVE Launcher can import Tranquility refresh tokens from the official EVE Launcher. This is useful when you already have accounts signed in through the official launcher and want ISBoxer EVE Launcher to launch without prompting for passwords.
+
+Before importing, enable **Save passwords (securely)** and **Use OAuth2 Refresh Tokens**. Imported refresh tokens are encrypted with your Master Password.
+
+Click **Import From EVE Launcher**, then select the accounts to import. Accounts that would overwrite existing ISBoxer EVE Launcher account data are unchecked by default. The header checkbox selects or clears all rows.
+
+Import requires the official EVE Launcher to be installed and signed in to at least one account. It also requires Windows support for AES-GCM; Windows 10 1809 or newer is required.
+
+## Saving EVE Account credentials
 ![Screenshot setting up a Master Password](http://i.imgur.com/7KbH007.png)
 
 EVE Account passwords are NOT stored by default. This means that each time you restart ISBoxer EVE Launcher, you will need to re-enter the password. To avoid having to re-enter your EVE Account passwords, you can enable 'Save passwords (securely)'. As soon as you tick this box, a window will pop up asking you to enter a Master Password; this Master Password will securely protect all of your EVE Account passwords, which will then be stored, securely encrypted in the settings file. The Master Password is never stored, and is discarded after creating the encryption key.
 
 When 'Save passwords (securely)' is enabled, launching ISBoxer EVE Launcher will prompt for your Master Password. If you forget the Master Password, click Cancel to skip entering it -- but note that attempting to log in to any EVE Account will again prompt for the password. If you forget or lose your Master Password, un-tick "Save passwords (securely)" to immediately discard any stored passwords, and disable the Master Password. You will need to create a Master Password again when re-enabling this option.
 
+The Master Password also protects stored OAuth2 refresh tokens. Refresh tokens are sensitive account credentials: treat them like passwords, and clear them with **Clear OAuth2 Refresh Tokens** if you want an account to re-authenticate.
+
 Tip: **The Master Password will need to be re-entered each time you launch ISBoxer EVE Launcher.** However, since version 1.0.0.5, you can leave an ISBoxer EVE Launcher instance running permanently, and any newly launched instances will securely transfer the Master Key from the master ISBoxer EVE Launcher instance. This will allow launches via command-line, desktop shortcuts, Inner Space, etc to automatically log in, instead of asking for your password again!
+
+## Manual login
+If automatic login is not working, enable **Manual login**. ISBoxer EVE Launcher will open an embedded WebView2 browser and ask you to complete the EVE Online login flow there.
+
+When **Manual Autofill** is enabled, ISBoxer EVE Launcher will try to fill and submit the username and password in the WebView2 login form. You may still need to complete any EVE SSO challenge manually.
+
+After a successful manual login, ISBoxer EVE Launcher stores the resulting refresh token when **Save passwords (securely)** and **Use OAuth2 Refresh Tokens** are enabled.
+
+## Debug Mode
+Enable **Debug Mode** only when troubleshooting login problems. Debug output is written to **ISBoxerEVELauncher.log** in the launcher data path.
+
+**Debug logs may contain sensitive authentication data, request details, response bodies, cookies, or tokens. Never share debug logs publicly or with anyone you do not trust.**
 
 ## Launching EVE Accounts without ISBoxer
 To launch one or more EVE Accounts, first highlight them in the list of accounts, and then click either "Launch with Inner Space" or "Launch Non-Inner Space", depending on whether you would like ISBoxer EVE Launcher to use the master Game Profile, or just directly launch EVE Online. Do note that if you're launching ISBoxer EVE Launcher itself through Inner Space, direct launches will still be "through Inner Space". '''ISBoxer EVE Launcher will launch the accounts in the order selected.'''
@@ -91,7 +132,7 @@ Here is a step-by-step description of updating your ISBoxer Character Set to use
 
 4. Add EVE Online Accounts to ISBoxer EVE Launcher using the Add Account button
 
-5. Optional: If you do not want to enter passwords each time, tick "Save passwords (securely)". This will ask for a Master Password which is then used to protect your EVE passwords.
+5. Optional: If you do not want to enter passwords each time, tick "Save passwords (securely)". This will ask for a Master Password which is then used to protect your EVE passwords and OAuth2 refresh tokens. You can also enable "Use OAuth2 Refresh Tokens" and use "Import From EVE Launcher" if your accounts are already signed in through the official EVE Launcher.
 
 6. Close Inner Space if it is running. This will make sure you don't have to do Step 7 twice under any circumstance...
 
@@ -108,6 +149,17 @@ Here is a step-by-step description of updating your ISBoxer Character Set to use
 12. **Launch your ISBoxer Character Set!** For example, right click Inner Space, and find your team under ISBoxer Character Sets. (Do not click "Launch with Inner Space", at all, if you are intending to use ISBoxer!) If your account-specific Game Profiles are created and assigned, your EVE clients should launch without further interaction with ISBoxer EVE Launcher unless a password (etc) is required.
 
 Tip: Most people asking for help so far have missed parts of Step #7, #9, or #12. I've adjusted the text and added emphasis to help you out!
+
+# Troubleshooting login
+If manual login reports that **WebView2Loader.dll** is missing, copy the full **runtimes** folder from the release zip into the same folder as ISBoxerEVELauncher.exe.
+
+If **Import From EVE Launcher** says EVE Launcher state was not found, open the official EVE Launcher and sign in to at least one Tranquility account first.
+
+If import cannot decrypt the EVE Launcher state, the official launcher profile may have been copied from another Windows user or machine. The encrypted key can only be unwrapped by the Windows user that created it.
+
+If a stored refresh token stops working, select the affected account and click **Clear OAuth2 Refresh Tokens**, then authenticate again or re-import from the official EVE Launcher.
+
+Use **Debug Mode** only while collecting troubleshooting data. Debug logs may contain sensitive data and should not be shared publicly.
 
 # Command-line parameters
 ISBoxer EVE Launcher supports the following command-line parameters:
@@ -145,3 +197,6 @@ This EVE Launcher is designed first and foremost to protect your accounts. Your 
 
 Other EVE Launchers may insecurely store your EVE Account data. As of my recent review, IsBridgeUp for example stores passwords encrypted, but they are stored alongside the encryption key and related details -- meaning that to steal your EVE Account passwords from IsBridgeUp, all that an attacker requires is its settings file. **ISBoxer EVE Launcher never stores encryption keys (or your Master Password), and your passwords cannot ever be recovered from ISBoxer EVE Launcher's settings file without your Master Password (keep it secret, keep it safe).**
 
+OAuth2 refresh tokens are also encrypted with your Master Password. Refresh tokens can be used to obtain access tokens for launching EVE, so protect them like passwords. Imported tokens from the official EVE Launcher are saved only after encryption.
+
+Manual login uses WebView2 data isolated per EVE account under your local application data. Debug Mode can write sensitive login details to disk, so leave it disabled unless you are actively troubleshooting.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Right-click an account and choose **Set Password...** to update its saved passwo
 ## Importing From EVE Launcher
 ISBoxer EVE Launcher can import Tranquility refresh tokens from the official EVE Launcher. This is useful when you already have accounts signed in through the official launcher and want ISBoxer EVE Launcher to launch without prompting for passwords.
 
-Before importing, enable **Save passwords (securely)** and **Use OAuth2 Refresh Tokens**. Imported refresh tokens are encrypted with your Master Password.
+Before importing, enable **Save credentials (securely)** and **Use OAuth2 Refresh Tokens**. Imported refresh tokens are encrypted with your Master Password.
 
 Click **Import From EVE Launcher**, then select the accounts to import. Accounts that would overwrite existing ISBoxer EVE Launcher account data are unchecked by default. The header checkbox selects or clears all rows.
 
@@ -62,9 +62,9 @@ Import requires the official EVE Launcher to be installed and signed in to at le
 ## Saving EVE Account credentials
 ![Screenshot setting up a Master Password](http://i.imgur.com/7KbH007.png)
 
-EVE Account passwords are NOT stored by default. This means that each time you restart ISBoxer EVE Launcher, you will need to re-enter the password. To avoid having to re-enter your EVE Account passwords, you can enable 'Save passwords (securely)'. As soon as you tick this box, a window will pop up asking you to enter a Master Password; this Master Password will securely protect all of your EVE Account passwords, which will then be stored, securely encrypted in the settings file. The Master Password is never stored, and is discarded after creating the encryption key.
+EVE Account passwords are NOT stored by default. This means that each time you restart ISBoxer EVE Launcher, you will need to re-enter the password. To avoid having to re-enter your EVE Account passwords, you can enable 'Save credentials (securely)'. As soon as you tick this box, a window will pop up asking you to enter a Master Password; this Master Password will securely protect all of your EVE Account credentials, which will then be stored, securely encrypted in the settings file. The Master Password is never stored, and is discarded after creating the encryption key.
 
-When 'Save passwords (securely)' is enabled, launching ISBoxer EVE Launcher will prompt for your Master Password. If you forget the Master Password, click Cancel to skip entering it -- but note that attempting to log in to any EVE Account will again prompt for the password. If you forget or lose your Master Password, un-tick "Save passwords (securely)" to immediately discard any stored passwords, and disable the Master Password. You will need to create a Master Password again when re-enabling this option.
+When 'Save credentials (securely)' is enabled, launching ISBoxer EVE Launcher will prompt for your Master Password. If you forget the Master Password, click Cancel to skip entering it -- but note that attempting to log in to any EVE Account will again prompt for the password. If you forget or lose your Master Password, un-tick "Save credentials (securely)" to immediately discard stored credentials protected by your Master Password, and disable the Master Password. You will need to create a Master Password again when re-enabling this option.
 
 The Master Password also protects stored OAuth2 refresh tokens. Refresh tokens are sensitive account credentials: treat them like passwords, and clear them with **Clear OAuth2 Refresh Tokens** if you want an account to re-authenticate.
 
@@ -75,7 +75,7 @@ If automatic login is not working, enable **Manual login**. ISBoxer EVE Launcher
 
 When **Manual Autofill** is enabled, ISBoxer EVE Launcher will try to fill and submit the username and password in the WebView2 login form. You may still need to complete any EVE SSO challenge manually.
 
-After a successful manual login, ISBoxer EVE Launcher stores the resulting refresh token when **Save passwords (securely)** and **Use OAuth2 Refresh Tokens** are enabled.
+After a successful manual login, ISBoxer EVE Launcher stores the resulting refresh token when **Save credentials (securely)** and **Use OAuth2 Refresh Tokens** are enabled.
 
 ## Debug Mode
 Enable **Debug Mode** only when troubleshooting login problems. Debug output is written to **ISBoxerEVELauncher.log** in the launcher data path.
@@ -132,7 +132,7 @@ Here is a step-by-step description of updating your ISBoxer Character Set to use
 
 4. Add EVE Online Accounts to ISBoxer EVE Launcher using the Add Account button
 
-5. Optional: If you do not want to enter passwords each time, tick "Save passwords (securely)". This will ask for a Master Password which is then used to protect your EVE passwords and OAuth2 refresh tokens. You can also enable "Use OAuth2 Refresh Tokens" and use "Import From EVE Launcher" if your accounts are already signed in through the official EVE Launcher.
+5. Optional: If you do not want to enter passwords each time, tick "Save credentials (securely)". This will ask for a Master Password which is then used to protect your EVE passwords and OAuth2 refresh tokens. You can also enable "Use OAuth2 Refresh Tokens" and use "Import From EVE Launcher" if your accounts are already signed in through the official EVE Launcher.
 
 6. Close Inner Space if it is running. This will make sure you don't have to do Step 7 twice under any circumstance...
 
@@ -144,7 +144,7 @@ Here is a step-by-step description of updating your ISBoxer Character Set to use
 
 10. Export to Inner Space
 
-11. Optional: If you have enabled "Save passwords (securely)" in Step 5, run an instance of ISBoxer EVE Launcher as Administrator now. This will act as a "master" ISBoxer EVE Launcher instance, which will allow the new instances to not ask you for the Master Password each time!
+11. Optional: If you have enabled "Save credentials (securely)" in Step 5, run an instance of ISBoxer EVE Launcher as Administrator now. This will act as a "master" ISBoxer EVE Launcher instance, which will allow the new instances to not ask you for the Master Password each time!
 
 12. **Launch your ISBoxer Character Set!** For example, right click Inner Space, and find your team under ISBoxer Character Sets. (Do not click "Launch with Inner Space", at all, if you are intending to use ISBoxer!) If your account-specific Game Profiles are created and assigned, your EVE clients should launch without further interaction with ISBoxer EVE Launcher unless a password (etc) is required.
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -359,6 +359,21 @@ namespace ISBoxerEVELauncher
                 OnPropertyChanged(nameof(ManualLoginAutofill));
             }
         }
+        
+        private bool _useRefreshhTokens = true;
+        
+        /// <summary>
+        /// If Manual Login Autofill is enabled
+        /// </summary>
+        public bool UseRefreshTokens
+        {
+            get => _useRefreshhTokens;
+            set
+            {
+                _useRefreshhTokens = value;
+                OnPropertyChanged(nameof(UseRefreshTokens));
+            }
+        }
 
         /// <summary>
         /// This is used to generate the Master Key Check, along with an IV and the Master Key
@@ -496,6 +511,8 @@ namespace ISBoxerEVELauncher
             {
                 account.EncryptPassword();
                 account.EncryptCharacterName();
+                account.EncryptTranquilityRefreshToken();
+                account.EncryptSisiRefreshToken();
             }
             Store();
         }

--- a/Web/CookieStorage.cs
+++ b/Web/CookieStorage.cs
@@ -22,12 +22,31 @@ namespace ISBoxerEVELauncher.Web
             string filename = eveAccount.Username.ToLowerInvariant().SHA256();
             return System.IO.Path.Combine(GetCookieStoragePath(), filename);
         }
+        
+        public static string GetWebViewCookiesFilename(EVEAccount eveAccount)
+        {
+            string filename = eveAccount.Username.ToLowerInvariant().SHA256() + "_webview";
+            return System.IO.Path.Combine(GetCookieStoragePath(), filename);
+        }
 
         public static string GetCookies(EVEAccount eveAccount)
         {
             try
             {
                 string filePath = GetCookiesFilename(eveAccount);
+                return System.IO.File.ReadAllText(filePath, Encoding.ASCII);
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+        
+        public static string GetWebViewCookies(EVEAccount eveAccount)
+        {
+            try
+            {
+                string filePath = GetWebViewCookiesFilename(eveAccount) + "_webview";
                 return System.IO.File.ReadAllText(filePath, Encoding.ASCII);
             }
             catch
@@ -85,11 +104,22 @@ namespace ISBoxerEVELauncher.Web
             string filePath = GetCookiesFilename(eveAccount);
             WriteAllTextSafe(filePath, cookies, Encoding.ASCII);
         }
-
+        
+        public static void SetWebViewCookies(EVEAccount eveAccount, string cookies)
+        {
+            string filePath = GetWebViewCookiesFilename(eveAccount) + "_webview";
+            WriteAllTextSafe(filePath, cookies, Encoding.ASCII);
+        }
 
         public static void DeleteCookies(EVEAccount eveAccount)
         {
             string filePath = GetCookiesFilename(eveAccount);
+            System.IO.File.Delete(filePath);
+        }
+        
+        public static void DeleteWebViewCookies(EVEAccount eveAccount)
+        {
+            string filePath = GetWebViewCookiesFilename(eveAccount) + "_webview";
             System.IO.File.Delete(filePath);
         }
     }

--- a/Web/RequestResponse.cs
+++ b/Web/RequestResponse.cs
@@ -1,5 +1,6 @@
 ﻿using ISBoxerEVELauncher.Enums;
 using ISBoxerEVELauncher.Extensions;
+using ISBoxerEVELauncher.Utils;
 using ISBoxerEVELauncher.Windows;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Win32;
@@ -12,6 +13,7 @@ namespace ISBoxerEVELauncher.Web
 {
     public static class RequestResponse
     {
+        private const string LogCategory = "RequestResponse";
 
         //public const string logoff = "/account/logoff";
         private const string auth = "/v2/oauth/authorize";
@@ -86,16 +88,30 @@ namespace ISBoxerEVELauncher.Web
 
         public static HttpWebRequest CreateGetRequest(Uri uri, bool sisi, bool origin, string referer, CookieContainer cookies)
         {
+            Debug.Info($"CreateGetRequest - Starting | URI: {uri} | Sisi: {sisi} | Origin: {origin} | Referer: {referer}", LogCategory);
             //.Replace("https:", "http:")
             if (!uri.IsAbsoluteUri)
-                uri = new Uri(string.Concat(sisi ? sisiBaseUri : tqBaseUri, uri.ToString()));
-            return CreateHttpWebRequest(uri, "GET", sisi, origin, referer, cookies);
+            {
+                var baseUri = sisi ? sisiBaseUri : tqBaseUri;
+                uri = new Uri(string.Concat(baseUri, uri.ToString()));
+                Debug.Info($"CreateGetRequest - Converted to absolute URI: {uri}", LogCategory);
+            }
+            var request = CreateHttpWebRequest(uri, "GET", sisi, origin, referer, cookies);
+            Debug.Info($"CreateGetRequest - Created request for: {request.RequestUri}", LogCategory);
+            return request;
         }
         public static HttpWebRequest CreatePostRequest(Uri uri, bool sisi, bool origin, string referer, CookieContainer cookies)
         {
+            Debug.Info($"CreatePostRequest - Starting | URI: {uri} | Sisi: {sisi} | Origin: {origin} | Referer: {referer}", LogCategory);
             if (!uri.IsAbsoluteUri)
-                uri = new Uri(string.Concat(sisi ? sisiBaseUri : tqBaseUri, uri.ToString()));
-            return CreateHttpWebRequest(uri, "POST", sisi, origin, referer, cookies);
+            {
+                var baseUri = sisi ? sisiBaseUri : tqBaseUri;
+                uri = new Uri(string.Concat(baseUri, uri.ToString()));
+                Debug.Info($"CreatePostRequest - Converted to absolute URI: {uri}", LogCategory);
+            }
+            var request = CreateHttpWebRequest(uri, "POST", sisi, origin, referer, cookies);
+            Debug.Info($"CreatePostRequest - Created request for: {request.RequestUri}", LogCategory);
+            return request;
         }
 
 
@@ -238,17 +254,22 @@ namespace ISBoxerEVELauncher.Web
 
         public static LoginResult GetHttpWebResponse(HttpWebRequest webRequest, Action updateCookies, out Response response)
         {
+            Debug.Info($"GetHttpWebResponse - Starting | URI: {webRequest.RequestUri} | Method: {webRequest.Method}", LogCategory);
             response = null;
 
             try
             {
+                Debug.Info($"GetHttpWebResponse - tofCaptcha flag: {App.tofCaptcha}", LogCategory);
                 if (!App.tofCaptcha)
                 {
+                    Debug.Info($"GetHttpWebResponse - Creating response from direct HTTP request", LogCategory);
                     response = new Response(webRequest);
+                    Debug.Info($"GetHttpWebResponse - Direct response created successfully", LogCategory);
                 }
             }
             catch (Exception e)
             {
+                Debug.Warning($"GetHttpWebResponse - Exception during direct request, enabling captcha flow: {e.Message}", LogCategory);
                 App.tofCaptcha = true;
             }
 
@@ -256,6 +277,7 @@ namespace ISBoxerEVELauncher.Web
             {
                 if (App.tofCaptcha)
                 {
+                    Debug.Info($"GetHttpWebResponse - Captcha flow enabled, opening browser window", LogCategory);
                     App.myLB = new EVELoginBrowser();
                     App.myLB.Clearup();
 
@@ -263,48 +285,61 @@ namespace ISBoxerEVELauncher.Web
 
                     if (webRequest.Method == "GET")
                     {
+                        Debug.Info($"GetHttpWebResponse - Browser navigating to (GET): {webRequest.Address}", LogCategory);
                         App.myLB.webBrowser_EVE.Navigate(webRequest.Address.ToString());
                     }
                     else
                     {
+                        Debug.Info($"GetHttpWebResponse - Browser navigating to (POST): {webRequest.Address}", LogCategory);
                         SetRegistery();
                         App.myLB.webBrowser_EVE.Navigate(webRequest.Address, string.Empty, App.requestBody, webRequest.Headers.ToString());
 
                     }
 
+                    Debug.Info($"GetHttpWebResponse - Showing browser dialog", LogCategory);
                     App.myLB.ShowDialog();
+                    Debug.Info($"GetHttpWebResponse - Browser dialog closed", LogCategory);
                 }
 
                 if (App.tofCaptcha)
                 {
+                    Debug.Info($"GetHttpWebResponse - Processing captcha flow result | HTML_Result empty: {string.IsNullOrEmpty(App.myLB.strHTML_Result)}", LogCategory);
                     if (App.myLB.strHTML_Result == "")
+                    {
+                        Debug.Error($"GetHttpWebResponse - Captcha flow returned empty result", LogCategory);
                         return LoginResult.Error;
+                    }
                     if (webRequest.Method == "GET")
                     {
+                        Debug.Info($"GetHttpWebResponse - Creating response from captcha flow (RequestVerificationToken)", LogCategory);
                         response = new Response(webRequest, WebRequestType.RequestVerificationToken);
                     }
                     else
                     {
+                        Debug.Info($"GetHttpWebResponse - Creating response from captcha flow (Result)", LogCategory);
                         response = new Response(webRequest, WebRequestType.Result);
                     }
                 }
 
                 if (updateCookies != null)
                 {
+                    Debug.Info($"GetHttpWebResponse - Updating cookies", LogCategory);
                     updateCookies();
                 }
             }
             catch (System.Net.WebException ex)
             {
+                Debug.Error($"GetHttpWebResponse - WebException: Status={ex.Status}, Message={ex.Message}", LogCategory);
                 switch (ex.Status)
                 {
                     case WebExceptionStatus.Timeout:
                         {
-
+                            Debug.Error($"GetHttpWebResponse - Request timed out", LogCategory);
                             return LoginResult.Timeout;
                         }
                     case WebExceptionStatus.ProtocolError:
                         {
+                            Debug.Error($"GetHttpWebResponse - Protocol error", LogCategory);
                             return LoginResult.Error;
                         }
                     default:
@@ -313,6 +348,7 @@ namespace ISBoxerEVELauncher.Web
                 }
             }
 
+            Debug.Info($"GetHttpWebResponse - Success | Response URI: {response?.ResponseUri}", LogCategory);
             return LoginResult.Success;
         }
 

--- a/Web/RequestResponse.cs
+++ b/Web/RequestResponse.cs
@@ -16,7 +16,7 @@ namespace ISBoxerEVELauncher.Web
         //public const string logoff = "/account/logoff";
         private const string auth = "/v2/oauth/authorize";
         private const string eula = "/v2/oauth/eula";
-        private const string logon = "/Account/LogOn";
+        private const string logon = "/account/logon";
         private const string launcher = "launcher";
         public const string token = "/v2/oauth/token";
         private const string tqBaseUri = "https://login.eveonline.com";

--- a/Web/RequestResponse.cs
+++ b/Web/RequestResponse.cs
@@ -19,6 +19,7 @@ namespace ISBoxerEVELauncher.Web
         private const string auth = "/v2/oauth/authorize";
         private const string eula = "/v2/oauth/eula";
         private const string logon = "/account/logon";
+        private const string logonPost = "/account/logon-username";
         private const string launcher = "launcher";
         public const string token = "/v2/oauth/token";
         private const string tqBaseUri = "https://login.eveonline.com";
@@ -48,6 +49,22 @@ namespace ISBoxerEVELauncher.Web
 
             return new Uri(logon, UriKind.Relative)
                 .AddQuery("ReturnUrl",
+                    new Uri(auth, UriKind.Relative)
+                        .AddQuery("client_id", "eveLauncherTQ")
+                        .AddQuery("response_type", "code")
+                        .AddQuery("scope", "eveClientLogin cisservice.customerRead.v1 cisservice.customerWrite.v1")
+                        .AddQuery("redirect_uri", new Uri(new Uri(sisi ? sisiBaseUri : tqBaseUri), launcher)
+                            .AddQuery("client_id", "eveLauncherTQ").ToString())
+                        .AddQuery("state", state)
+                        .AddQuery("code_challenge_method", "S256")
+                        .AddQuery("code_challenge", challengeHash)
+                        .AddQuery("showRemember", "true").ToString());
+        }
+
+        public static Uri GetLoginPostUri(bool sisi, string state, string challengeHash)
+        {
+            return new Uri(logonPost, UriKind.Relative)
+                .AddQuery("returnUrl",
                     new Uri(auth, UriKind.Relative)
                         .AddQuery("client_id", "eveLauncherTQ")
                         .AddQuery("response_type", "code")

--- a/Web/Response.cs
+++ b/Web/Response.cs
@@ -1,6 +1,7 @@
 ﻿using HtmlAgilityPack;
 using ISBoxerEVELauncher.Enums;
 using ISBoxerEVELauncher.Extensions;
+using ISBoxerEVELauncher.Utils;
 using Newtonsoft.Json;
 using System;
 using System.Net;
@@ -9,6 +10,8 @@ namespace ISBoxerEVELauncher.Web
 {
     public class Response
     {
+        private const string LogCategory = "Response";
+
         Uri _requestUri = null;
         string _origin;
         string _referer;
@@ -19,20 +22,36 @@ namespace ISBoxerEVELauncher.Web
 
         public Response(HttpWebRequest request)
         {
-            using (var response = (HttpWebResponse)request.GetResponse())
+            Debug.Info($"Response(HttpWebRequest) - Creating response from request to: {request.RequestUri}", LogCategory);
+            try
             {
-                _requestUri = request.RequestUri;
-                _origin = request.Headers["Origin"];
-                _referer = request.Referer;
-                _response = response.StatusCode;
-                _responseLocation = response.Headers["Location"];
-                _responseBody = response.GetResponseBody();
-                _responseUri = response.ResponseUri;
+                using (var response = (HttpWebResponse)request.GetResponse())
+                {
+                    _requestUri = request.RequestUri;
+                    _origin = request.Headers["Origin"];
+                    _referer = request.Referer;
+                    _response = response.StatusCode;
+                    _responseLocation = response.Headers["Location"];
+                    _responseBody = response.GetResponseBody();
+                    _responseUri = response.ResponseUri;
+                    Debug.Info($"Response(HttpWebRequest) - Status: {_response} | ResponseUri: {_responseUri} | Body length: {_responseBody?.Length ?? 0}", LogCategory);
+                }
+            }
+            catch (WebException ex)
+            {
+                Debug.Error($"Response(HttpWebRequest) - WebException: {ex.Status} - {ex.Message}", LogCategory);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Debug.Error($"Response(HttpWebRequest) - Exception: {ex.Message}", LogCategory);
+                throw;
             }
         }
 
         public Response(HttpWebRequest request, string responseBody)
         {
+            Debug.Info($"Response(HttpWebRequest, string) - Creating response with provided body for: {request.RequestUri}", LogCategory);
             _requestUri = request.RequestUri;
             _origin = request.Headers["Origin"];
             _referer = request.Referer;
@@ -40,10 +59,12 @@ namespace ISBoxerEVELauncher.Web
             _responseLocation = null;
             _responseBody = responseBody;
             _responseUri = _requestUri;
+            Debug.Info($"Response(HttpWebRequest, string) - Body length: {_responseBody?.Length ?? 0}", LogCategory);
         }
 
         public Response(HttpWebRequest request, WebRequestType requestType)
         {
+            Debug.Info($"Response(HttpWebRequest, WebRequestType) - Creating response with type: {requestType} for: {request.RequestUri}", LogCategory);
             _requestUri = request.RequestUri;
             _origin = request.Headers["Origin"];
             _referer = request.Referer;
@@ -53,18 +74,22 @@ namespace ISBoxerEVELauncher.Web
             switch (requestType)
             {
                 case WebRequestType.RequestVerificationToken:
+                    Debug.Info($"Response(HttpWebRequest, WebRequestType) - Using RequestVerificationToken from browser | URL: {App.myLB.strURL_RequestVerificationToken}", LogCategory);
                     _responseBody = App.myLB.strHTML_RequestVerificationToken;
                     _responseUri = new Uri(App.myLB.strURL_RequestVerificationToken, UriKind.Absolute);
                     break;
                 case WebRequestType.VerficationCode:
+                    Debug.Info($"Response(HttpWebRequest, WebRequestType) - Using VerficationCode from browser | URL: {App.myLB.strURL_VerficationCode}", LogCategory);
                     _responseBody = App.myLB.strHTML_VerficationCode;
                     _responseUri = new Uri(App.myLB.strURL_VerficationCode, UriKind.Absolute);
                     break;
                 case WebRequestType.Result:
+                    Debug.Info($"Response(HttpWebRequest, WebRequestType) - Using Result from browser | URL: {App.myLB.strURL_Result}", LogCategory);
                     _responseBody = App.myLB.strHTML_Result;
                     _responseUri = new Uri(App.myLB.strURL_Result, UriKind.Absolute);
                     break;
             }
+            Debug.Info($"Response(HttpWebRequest, WebRequestType) - Body length: {_responseBody?.Length ?? 0} | ResponseUri: {_responseUri}", LogCategory);
 
         }
 

--- a/Windows/EVELogin.xaml
+++ b/Windows/EVELogin.xaml
@@ -12,10 +12,6 @@
             <TextBlock Width="120" DockPanel.Dock="Left" HorizontalAlignment="Left" TextWrapping="Wrap" Text="Password" VerticalAlignment="Center"/>
             <PasswordBox DockPanel.Dock="Right" Name="textPassword" HorizontalAlignment="Stretch" Height="23" VerticalAlignment="Top" />
         </DockPanel>
-        <DockPanel DockPanel.Dock="Top" Margin="5,0,5,5">
-            <TextBlock Width="120" DockPanel.Dock="Left" HorizontalAlignment="Left" TextWrapping="Wrap" Text="Profile" VerticalAlignment="Center"/>
-            <ComboBox DockPanel.Dock="Left" Name="comboProfiles" HorizontalAlignment="Stretch"  VerticalAlignment="Top"  />
-        </DockPanel>
         <DockPanel DockPanel.Dock="Bottom" Margin="5,5,5,5">
             <Button DockPanel.Dock="Right" Name="buttonGo"  Content="Go" VerticalAlignment="Top" Width="75" Click="buttonGo_Click" IsDefault="True" />
             <Button DockPanel.Dock="Right" x:Name="buttonCancel" IsCancel="True"  Content="Cancel" HorizontalAlignment="Right" Margin="5,0,5,0" VerticalAlignment="Top" Width="75" Click="buttonCancel_Click" />

--- a/Windows/EVELoginBrowser.cs
+++ b/Windows/EVELoginBrowser.cs
@@ -128,7 +128,6 @@ namespace ISBoxerEVELauncher.Windows
                 {
                     webBrowser_EVE.Document.GetElementById("UserName").SetAttribute("value", App.strUserName);
                     webBrowser_EVE.Document.GetElementById("Password").SetAttribute("value", App.strPassword);
-                    webBrowser_EVE.Document.GetElementById("RememberMe").InvokeMember("click");
 
                     //var cookies = BrowserCookie.GetCookieInternal(webBrowser_EVE.Url, false);
 

--- a/Windows/EVEManualLogin.xaml.cs
+++ b/Windows/EVEManualLogin.xaml.cs
@@ -22,6 +22,8 @@ namespace ISBoxerEVELauncher.Windows
 {
     public partial class EVEManualLogin : Window, INotifyPropertyChanged
     {
+        private const string LogCategory = "EVEManualLogin";
+
         private readonly EVEAccount _account;
         private readonly bool _sisi;
         private string _loginUrl;
@@ -36,6 +38,7 @@ namespace ISBoxerEVELauncher.Windows
 
         public EVEManualLogin(EVEAccount account, bool sisi)
         {
+            Debug.Info($"EVEManualLogin - Constructor starting | Username: {account.Username} | Sisi: {sisi}", LogCategory);
             _account = account;
             _sisi = sisi;
             LoginResult = LoginResult.Error;
@@ -43,11 +46,13 @@ namespace ISBoxerEVELauncher.Windows
             var challengeCodeSource = Guid.NewGuid();
             _challengeCode = Encoding.UTF8.GetBytes(challengeCodeSource.ToString().Replace("-", ""));
             _challengeHash = Base64UrlEncoder.Encode(ISBoxerEVELauncher.Security.SHA256.GenerateHash(Base64UrlEncoder.Encode(_challengeCode)));
-            
+            Debug.Info($"EVEManualLogin - Challenge hash generated: {_challengeHash.Substring(0, Math.Min(10, _challengeHash.Length))}...", LogCategory);
+
             InitializeComponent();
             Instructions = "Please log in to your EVE Online account in the browser below.";
             Closing += OnWindowClosing;
             InitializeWebView();
+            Debug.Info($"EVEManualLogin - Constructor completed", LogCategory);
         }
 
         private bool VerifyWebView2LoaderExists()
@@ -84,124 +89,165 @@ namespace ISBoxerEVELauncher.Windows
 
         private async void InitializeWebView()
         {
+            Debug.Info($"InitializeWebView - Starting", LogCategory);
             try
             {
                 // Verify WebView2Loader.dll exists in the runtimes directory
                 if (!VerifyWebView2LoaderExists())
                 {
+                    Debug.Error($"InitializeWebView - WebView2Loader.dll not found", LogCategory);
                     CloseWithResult(LoginResult.Error);
                     return;
                 }
 
                 // We set this into userdata folder as Innerspace folder is write protected
+                var userDataFolder = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                    "ISBoxerEVELauncher",
+                    "WebViews",
+                    _account.Username);
+                Debug.Info($"InitializeWebView - Setting up WebView2 with UserDataFolder: {userDataFolder}", LogCategory);
+
                 WebView2.CreationProperties = new CoreWebView2CreationProperties()
                 {
                     ProfileName = _account.Username,
-                    UserDataFolder = Path.Combine(
-                        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                        "ISBoxerEVELauncher",
-                        "WebViews",
-                        _account.Username)
+                    UserDataFolder = userDataFolder
                 };
-                
+
+                Debug.Info($"InitializeWebView - Ensuring CoreWebView2 is initialized", LogCategory);
                 await WebView2.EnsureCoreWebView2Async(null);
+                Debug.Info($"InitializeWebView - CoreWebView2 initialized successfully", LogCategory);
 
                 // Load saved cookies if available
+                Debug.Info($"InitializeWebView - Loading saved cookies", LogCategory);
                 await LoadCookiesAsync();
 
                 // Setup navigation completed handler
                 WebView2.NavigationCompleted += WebView2_NavigationCompleted;
-                
+
                 var uri = RequestResponse.FullUri(_sisi, RequestResponse.GetLoginUri(_sisi, _state.ToString() , _challengeHash));
+                Debug.Info($"InitializeWebView - Navigating to login URI: {uri}", LogCategory);
 
                 Navigate(uri.ToString());
             }
             catch (Exception ex)
             {
+                Debug.Error($"InitializeWebView - Exception: {ex.Message}", LogCategory);
                 MessageBox.Show($"Failed to initialize WebView2: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
 
         private void Navigate(string url)
         {
+            Debug.Info($"Navigate - Navigating to: {url}", LogCategory);
             if (WebView2?.CoreWebView2 != null)
             {
                 WebView2.CoreWebView2.Navigate(url);
+            }
+            else
+            {
+                Debug.Warning($"Navigate - WebView2 or CoreWebView2 is null, cannot navigate", LogCategory);
             }
         }
 
         private async void WebView2_NavigationCompleted(object sender, CoreWebView2NavigationCompletedEventArgs e)
         {
+            Debug.Info($"WebView2_NavigationCompleted - Navigation completed | IsSuccess: {e.IsSuccess} | WebErrorStatus: {e.WebErrorStatus}", LogCategory);
             try
             {
                 LoginUrl = WebView2.CoreWebView2.Source;
+                Debug.Info($"WebView2_NavigationCompleted - Current URL: {LoginUrl}", LogCategory);
 
                 if (e.IsSuccess)
                 {
                     await ProcessNavigationAsync();
                 }
+                else
+                {
+                    Debug.Warning($"WebView2_NavigationCompleted - Navigation was not successful: {e.WebErrorStatus}", LogCategory);
+                }
             }
             catch (Exception ex)
             {
+                Debug.Error($"WebView2_NavigationCompleted - Exception: {ex.Message}", LogCategory);
                 MessageBox.Show($"Navigation error: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
             }
         }
 
         private async Task ProcessNavigationAsync()
         {
+            Debug.Info($"ProcessNavigationAsync - Starting", LogCategory);
             try
             {
                 if (WebView2 == null || WebView2.CoreWebView2 == null)
+                {
+                    Debug.Warning($"ProcessNavigationAsync - WebView2 or CoreWebView2 is null, skipping", LogCategory);
                     return;
-                
+                }
+
                 var url = WebView2.CoreWebView2.Source;
+                Debug.Info($"ProcessNavigationAsync - Current URL: {url}", LogCategory);
                 var html = await WebView2.CoreWebView2.ExecuteScriptAsync("document.documentElement.outerHTML;");
-                
-                Debug.Info($"Navigated to URL: {url}");
-                Debug.Info($"HTML: {html}");
-                
+
+                Debug.Info($"ProcessNavigationAsync - HTML length: {html?.Length ?? 0}", LogCategory);
+                Debug.Info($"ProcessNavigationAsync - HTML contains loginForm: {html?.Contains("loginForm") ?? false}", LogCategory);
+                Debug.Info($"ProcessNavigationAsync - Full HTML:{Environment.NewLine}{html}", LogCategory);
+
                 if (html.Contains("loginForm") && App.Settings.ManualLoginAutofill)
                 {
+                    Debug.Info($"ProcessNavigationAsync - Login form detected, autofill enabled", LogCategory);
                     FillAndCheckState(LoginState.LoginForm);
                     // Fill in username and password
-                    // Sadly we cannot get around the SecureString to string conversion here as we have to 
+                    // Sadly we cannot get around the SecureString to string conversion here as we have to
                     // inject it into JavaScript
                     var password = GetEscapedPasswordString();
+                    Debug.Info($"ProcessNavigationAsync - Filling in username: {_account.Username} and password (hidden)", LogCategory);
                     string script = $@"
                         document.getElementById('UserName').value = '{_account.Username}';
                         document.getElementById('Password').value = '{password}';
                         document.forms['loginForm'].submit();
                     ";
+                    Debug.Info($"ProcessNavigationAsync - Submitting login form", LogCategory);
                     await WebView2.CoreWebView2.ExecuteScriptAsync(script);
                     return;
                 }
 
                 var codeUri = RequestResponse.FullUri(_sisi, new Uri("/launcher", UriKind.Relative));
+                Debug.Info($"ProcessNavigationAsync - Checking if URL matches launcher URI: {codeUri}", LogCategory);
                 if (url.StartsWith(codeUri.ToString(), StringComparison.OrdinalIgnoreCase))
                 {
-                    
+                    Debug.Info($"ProcessNavigationAsync - URL matches launcher URI, extracting auth code", LogCategory);
+
                     var authCode = HttpUtility.ParseQueryString(url).Get("code");
+                    Debug.Info($"ProcessNavigationAsync - Auth code extracted: {(string.IsNullOrEmpty(authCode) ? "null/empty" : $"length {authCode.Length}")}", LogCategory);
                     if (string.IsNullOrEmpty(authCode))
                     {
+                        Debug.Error($"ProcessNavigationAsync - No auth code found in URL", LogCategory);
                         MessageBox.Show("Launcher page did not retun a valid code.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
                         CloseWithResult(LoginResult.Error);
                         return;
                     }
 
+                    Debug.Info($"ProcessNavigationAsync - Exchanging auth code for token", LogCategory);
                     var tokenUri = RequestResponse.FullUri(_sisi, RequestResponse.GetTokenUri(_sisi));
-                    
+
                     var req2 = RequestResponse.CreatePostRequest(new Uri(RequestResponse.token, UriKind.Relative), _sisi, true, RequestResponse.refererUri, null);
                     req2.SetBody(RequestResponse.GetSsoTokenRequestBody(_sisi, authCode, _challengeCode));
+                    Debug.Info($"ProcessNavigationAsync - Sending token request to: {req2.RequestUri}", LogCategory);
                     var respone = new Response(req2);
-                    
+                    Debug.Info($"ProcessNavigationAsync - Token response received, body length: {respone.Body?.Length ?? 0}", LogCategory);
+
                     var accessToken = new EVEAccount.Token(JsonConvert.DeserializeObject<EVEAccount.authObj>(respone.Body));
+                    Debug.Info($"ProcessNavigationAsync - Token parsed | Has refresh token: {!string.IsNullOrEmpty(accessToken.RefreshToken)} | Expiration: {accessToken.Expiration}", LogCategory);
                     if (string.IsNullOrEmpty(accessToken.RefreshToken))
                     {
+                        Debug.Error($"ProcessNavigationAsync - No refresh token in response", LogCategory);
                         MessageBox.Show("Failed to retrieve access token.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
                         CloseWithResult(LoginResult.Error);
                         return;
                     }
-                    
+
+                    Debug.Info($"ProcessNavigationAsync - Storing token for {(_sisi ? "Sisi" : "Tranquility")}", LogCategory);
                     if (_sisi)
                     {
                         _account.SisiToken = accessToken;
@@ -212,12 +258,16 @@ namespace ISBoxerEVELauncher.Windows
                     }
 
                     AccessToken = accessToken;
+                    Debug.Info($"ProcessNavigationAsync - Login successful", LogCategory);
                     CloseWithResult(LoginResult.Success);
                     return;
                 }
+
+                Debug.Info($"ProcessNavigationAsync - URL did not match known patterns, waiting for user interaction", LogCategory);
             }
             catch (Exception ex)
             {
+                Debug.Error($"ProcessNavigationAsync - Exception: {ex.Message}", ex, LogCategory);
                 MessageBox.Show($"Process error: {ex.Message}", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
                 CloseWithResult(LoginResult.Error);
             }
@@ -235,17 +285,21 @@ namespace ISBoxerEVELauncher.Windows
 
         private void FillAndCheckState(LoginState state)
         {
+            Debug.Info($"FillAndCheckState - Checking state: {state} | Already visited: {_visitedStates.Contains(state)}", LogCategory);
             if (_visitedStates.Contains(state))
             {
+                Debug.Error($"FillAndCheckState - Loop detected! State {state} has already been visited", LogCategory);
                 MessageBox.Show("Looping detected during login process.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
                 CloseWithResult(LoginResult.Error);
                 return;
             }
             _visitedStates.Add(state);
+            Debug.Info($"FillAndCheckState - Added state {state} to visited states", LogCategory);
         }
-        
+
         private void CloseWithResult(LoginResult result)
         {
+            Debug.Info($"CloseWithResult - Closing with result: {result}", LogCategory);
             LoginResult = result;
             WebView2.NavigationCompleted -= WebView2_NavigationCompleted;
             this.Close();
@@ -253,8 +307,12 @@ namespace ISBoxerEVELauncher.Windows
 
         private async Task LoadCookiesAsync()
         {
+            Debug.Info($"LoadCookiesAsync - Starting | Has stored cookies: {!string.IsNullOrEmpty(_account.WebView2CookieStorage)}", LogCategory);
             if (string.IsNullOrEmpty(_account.WebView2CookieStorage))
+            {
+                Debug.Info($"LoadCookiesAsync - No cookies to load", LogCategory);
                 return;
+            }
 
             try
             {
@@ -264,8 +322,12 @@ namespace ISBoxerEVELauncher.Windows
 
                 var cookies = JsonConvert.DeserializeObject<List<CookieData>>(json);
                 if (cookies == null)
+                {
+                    Debug.Warning($"LoadCookiesAsync - Cookie deserialization returned null", LogCategory);
                     return;
+                }
 
+                Debug.Info($"LoadCookiesAsync - Loaded {cookies.Count} cookies from storage", LogCategory);
                 var cookieManager = WebView2.CoreWebView2.CookieManager;
                 foreach (var cookieData in cookies)
                 {
@@ -276,24 +338,34 @@ namespace ISBoxerEVELauncher.Windows
 
                     cookieManager.AddOrUpdateCookie(cookie);
                 }
+                Debug.Info($"LoadCookiesAsync - All cookies loaded successfully", LogCategory);
             }
             catch (Exception ex)
             {
+                Debug.Error($"LoadCookiesAsync - Exception: {ex.Message}", LogCategory);
                 MessageBox.Show($"Failed to load cookies: {ex.Message}", "Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
             }
         }
 
         private async Task SaveCookiesAsync()
         {
+            Debug.Info($"SaveCookiesAsync - Starting", LogCategory);
             try
             {
                 var cookieManager = WebView2?.CoreWebView2?.CookieManager;
                 if (cookieManager == null)
+                {
+                    Debug.Warning($"SaveCookiesAsync - CookieManager is null, cannot save cookies", LogCategory);
                     return;
+                }
                 var cookies = await cookieManager.GetCookiesAsync(null);
                 if (cookies == null || cookies.Count == 0)
+                {
+                    Debug.Info($"SaveCookiesAsync - No cookies to save", LogCategory);
                     return;
+                }
 
+                Debug.Info($"SaveCookiesAsync - Saving {cookies.Count} cookies", LogCategory);
                 var cookieDataList = cookies.Select(c => new CookieData
                 {
                     Name = c.Name,
@@ -309,15 +381,18 @@ namespace ISBoxerEVELauncher.Windows
                 string json = JsonConvert.SerializeObject(cookieDataList);
                 byte[] data = System.Text.Encoding.UTF8.GetBytes(json);
                 _account.WebView2CookieStorage = Convert.ToBase64String(data);
+                Debug.Info($"SaveCookiesAsync - Cookies saved successfully", LogCategory);
             }
             catch (Exception ex)
             {
+                Debug.Error($"SaveCookiesAsync - Exception: {ex.Message}", LogCategory);
                 MessageBox.Show($"Failed to save cookies: {ex.Message}", "Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
             }
         }
 
         private async void OnWindowClosing(object sender, System.ComponentModel.CancelEventArgs e)
         {
+            Debug.Info($"OnWindowClosing - Window closing, saving cookies", LogCategory);
             await SaveCookiesAsync();
         }
 

--- a/Windows/EVEManualLogin.xaml.cs
+++ b/Windows/EVEManualLogin.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -14,6 +15,7 @@ using ISBoxerEVELauncher.Utils;
 using ISBoxerEVELauncher.Web;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.Wpf;
 using Newtonsoft.Json;
 
 namespace ISBoxerEVELauncher.Windows
@@ -52,6 +54,17 @@ namespace ISBoxerEVELauncher.Windows
         {
             try
             {
+                // We set this into userdata folder as Innerspace folder is write protected
+                WebView2.CreationProperties = new CoreWebView2CreationProperties()
+                {
+                    ProfileName = _account.Username,
+                    UserDataFolder = Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                        "ISBoxerEVELauncher",
+                        "WebViews",
+                        _account.Username)
+                };
+                
                 await WebView2.EnsureCoreWebView2Async(null);
 
                 // Load saved cookies if available

--- a/Windows/ImportFromEVELauncherWindow.xaml
+++ b/Windows/ImportFromEVELauncherWindow.xaml
@@ -19,6 +19,11 @@
             <ListView.View>
                 <GridView>
                     <GridViewColumn Width="40">
+                        <GridViewColumn.Header>
+                            <CheckBox Name="checkAll"
+                                      Checked="checkAll_Checked" Unchecked="checkAll_Unchecked"
+                                      ToolTip="Select/deselect all" />
+                        </GridViewColumn.Header>
                         <GridViewColumn.CellTemplate>
                             <DataTemplate>
                                 <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />

--- a/Windows/ImportFromEVELauncherWindow.xaml
+++ b/Windows/ImportFromEVELauncherWindow.xaml
@@ -1,0 +1,34 @@
+<Window x:Class="ISBoxerEVELauncher.Windows.ImportFromEVELauncherWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="ISBoxer EVE Launcher: Import From EVE Launcher" Height="360" Width="520"
+        SizeToContent="Height" WindowStartupLocation="CenterOwner"
+        Name="windowImportFromLauncher">
+    <DockPanel>
+        <TextBlock DockPanel.Dock="Top" HorizontalAlignment="Stretch" Margin="10,10,10,0" TextWrapping="Wrap" FontWeight="Bold"
+                   Text="Select accounts to import from the official EVE Launcher" />
+        <TextBlock DockPanel.Dock="Top" HorizontalAlignment="Stretch" Margin="10,4,10,8" TextWrapping="Wrap"
+                   Text="Refresh tokens will be encrypted with your Master Password and saved. Accounts that would overwrite existing data are unchecked by default." />
+        <DockPanel DockPanel.Dock="Bottom" Margin="10,5,10,10">
+            <Button DockPanel.Dock="Right" Name="buttonImport" Content="Import" Width="80" IsDefault="True" Click="buttonImport_Click" />
+            <Button DockPanel.Dock="Right" Name="buttonCancel" Content="Cancel" Width="80" Margin="0,0,5,0" IsCancel="True" Click="buttonCancel_Click" />
+            <TextBlock />
+        </DockPanel>
+        <ListView Name="listRows" Margin="10,0,10,5" ItemsSource="{Binding ElementName=windowImportFromLauncher, Path=Rows}"
+                  HorizontalAlignment="Stretch" VerticalAlignment="Stretch" MinHeight="160">
+            <ListView.View>
+                <GridView>
+                    <GridViewColumn Width="40">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
+                    <GridViewColumn Header="Account" Width="220" DisplayMemberBinding="{Binding Username}" />
+                    <GridViewColumn Header="Action" Width="220" DisplayMemberBinding="{Binding ActionText}" />
+                </GridView>
+            </ListView.View>
+        </ListView>
+    </DockPanel>
+</Window>

--- a/Windows/ImportFromEVELauncherWindow.xaml.cs
+++ b/Windows/ImportFromEVELauncherWindow.xaml.cs
@@ -1,0 +1,78 @@
+using ISBoxerEVELauncher.Games.EVE;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+
+namespace ISBoxerEVELauncher.Windows
+{
+    public partial class ImportFromEVELauncherWindow : Window
+    {
+        public ImportFromEVELauncherWindow(IEnumerable<ImportCandidate> candidates, IEnumerable<EVEAccount> existingAccounts)
+        {
+            var existing = existingAccounts ?? new EVEAccount[0];
+            Rows = new ObservableCollection<ImportRow>();
+            foreach (var c in candidates)
+            {
+                bool overwrites = existing.Any(a => !string.IsNullOrEmpty(a.Username)
+                    && a.Username.Equals(c.Username, StringComparison.InvariantCultureIgnoreCase));
+                Rows.Add(new ImportRow
+                {
+                    Candidate = c,
+                    Username = c.Username,
+                    ActionText = overwrites ? "Overwrite existing" : "New account",
+                    IsSelected = !overwrites,
+                });
+            }
+            InitializeComponent();
+        }
+
+        public ObservableCollection<ImportRow> Rows { get; }
+
+        public IReadOnlyList<ImportCandidate> SelectedCandidates
+        {
+            get { return Rows.Where(r => r.IsSelected).Select(r => r.Candidate).ToList(); }
+        }
+
+        private void buttonImport_Click(object sender, RoutedEventArgs e)
+        {
+            e.Handled = true;
+            if (!Rows.Any(r => r.IsSelected))
+            {
+                MessageBox.Show("Select at least one account to import.");
+                return;
+            }
+            DialogResult = true;
+            Close();
+        }
+
+        private void buttonCancel_Click(object sender, RoutedEventArgs e)
+        {
+            e.Handled = true;
+            DialogResult = false;
+            Close();
+        }
+
+        public class ImportRow : INotifyPropertyChanged
+        {
+            private bool _isSelected;
+            public ImportCandidate Candidate { get; set; }
+            public string Username { get; set; }
+            public string ActionText { get; set; }
+            public bool IsSelected
+            {
+                get { return _isSelected; }
+                set
+                {
+                    if (_isSelected == value) return;
+                    _isSelected = value;
+                    var h = PropertyChanged;
+                    if (h != null) h(this, new PropertyChangedEventArgs("IsSelected"));
+                }
+            }
+            public event PropertyChangedEventHandler PropertyChanged;
+        }
+    }
+}

--- a/Windows/ImportFromEVELauncherWindow.xaml.cs
+++ b/Windows/ImportFromEVELauncherWindow.xaml.cs
@@ -10,6 +10,8 @@ namespace ISBoxerEVELauncher.Windows
 {
     public partial class ImportFromEVELauncherWindow : Window
     {
+        private bool _suppressSync;
+
         public ImportFromEVELauncherWindow(IEnumerable<ImportCandidate> candidates, IEnumerable<EVEAccount> existingAccounts)
         {
             var existing = existingAccounts ?? new EVEAccount[0];
@@ -18,15 +20,57 @@ namespace ISBoxerEVELauncher.Windows
             {
                 bool overwrites = existing.Any(a => !string.IsNullOrEmpty(a.Username)
                     && a.Username.Equals(c.Username, StringComparison.InvariantCultureIgnoreCase));
-                Rows.Add(new ImportRow
+                var row = new ImportRow
                 {
                     Candidate = c,
                     Username = c.Username,
                     ActionText = overwrites ? "Overwrite existing" : "New account",
                     IsSelected = !overwrites,
-                });
+                };
+                row.PropertyChanged += Row_PropertyChanged;
+                Rows.Add(row);
             }
             InitializeComponent();
+            UpdateHeaderCheckState();
+        }
+
+        private void Row_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == "IsSelected") UpdateHeaderCheckState();
+        }
+
+        private void UpdateHeaderCheckState()
+        {
+            if (_suppressSync || checkAll == null) return;
+            int total = Rows.Count;
+            int selected = Rows.Count(r => r.IsSelected);
+            _suppressSync = true;
+            try
+            {
+                checkAll.IsChecked = (total > 0 && selected == total);
+            }
+            finally { _suppressSync = false; }
+        }
+
+        private void SetAllSelected(bool value)
+        {
+            if (_suppressSync) return;
+            _suppressSync = true;
+            try
+            {
+                foreach (var r in Rows) r.IsSelected = value;
+            }
+            finally { _suppressSync = false; }
+        }
+
+        private void checkAll_Checked(object sender, RoutedEventArgs e)
+        {
+            SetAllSelected(true);
+        }
+
+        private void checkAll_Unchecked(object sender, RoutedEventArgs e)
+        {
+            SetAllSelected(false);
         }
 
         public ObservableCollection<ImportRow> Rows { get; }

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -51,8 +51,24 @@
                         <ScrollViewer Margin="5,0,0,0" Width="187" VerticalScrollBarVisibility="Auto">
                             <StackPanel>
                                 <CheckBox Name="checkSavePasswords" Content="Save passwords (securely)" Margin="0,3,0,0" Click="checkSavePasswords_Click" />
+                                <CheckBox Name="checkUseRefreshTokens" Content="Use OAuth2 Refresh Tokens" Margin="0,3,0,0" IsChecked="{Binding ElementName=mainWindow, Path=UseRefreshTokens}">
+                                    <CheckBox.ToolTip>
+                                        <TextBlock TextWrapping="Wrap" Width="200">Use OAuth2 Refresh Tokens to log in, instead of username and passwords.</TextBlock>
+                                    </CheckBox.ToolTip>
+                                </CheckBox>
                                 <Button Name="buttonAddAccount" Content="Add Account"  Margin="0,3,0,0" Click="buttonAddAccount_Click" />
                                 <Button Name="buttonDelete" Content="Delete Account(s)" Click="buttonDeleteAccount_Click" Margin="0,3,0,0" >
+                                    <Button.Style>
+                                        <Style>
+                                            <Style.Triggers>
+                                                <DataTrigger Binding ="{Binding ElementName=listAccounts, Path=SelectedIndex}" Value="-1">
+                                                    <Setter Property="Button.IsEnabled" Value="false"/>
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Button.Style>
+                                </Button>
+                                <Button Name="buttonClearTokens" Content="Clear OAuth2 Refresh Tokens" Click="buttonClearTokens_Click" Margin="0,3,0,0" >
                                     <Button.Style>
                                         <Style>
                                             <Style.Triggers>
@@ -151,7 +167,7 @@
                             </ListBox.ItemTemplate>
                         </ListBox>
                         <DockPanel  Margin="5,0,0,0" Width="187" Height="240">
-                            <CheckBox DockPanel.Dock="Top" x:Name="checkSaveCharacterPasswords" Content="Save passwords (securely)" Margin="0,3,0,0" Click="checkSavePasswords_Click" IsChecked="{Binding IsChecked, ElementName=checkSavePasswords}" />
+                            <CheckBox DockPanel.Dock="Top" x:Name="checkSaveCharacterPasswords" Content="Save passwords (securely)" Margin="0,3,0,0" Click="checkSavePasswords_Click" IsChecked="{Binding IsChecked, ElementName=checkUseRefreshTokens}" />
                             <Button DockPanel.Dock="Top" x:Name="buttonAddCharacter" Content="Add Character" Click="buttonAddCharacter_Click" Margin="0,3,0,0" />
                             <Button DockPanel.Dock="Top" x:Name="buttonDeleteCharacter" Content="Delete Character(s)" Click="buttonDeleteCharacter_Click" Margin="0,3,0,0" VerticalAlignment="Top" >
                                 <Button.Style>
@@ -213,7 +229,6 @@
                                         </Style>
                                     </Button.Style>
                                 </Button>
-                                
                             </StackPanel>
                         </DockPanel>
                     </StackPanel>

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -38,12 +38,22 @@
                 <DockPanel DockPanel.Dock="Bottom" VerticalAlignment="Stretch">
                     <TextBlock DockPanel.Dock="Top" HorizontalAlignment="Left" Margin="15,0,0,0" TextWrapping="Wrap" FontWeight="Bold" Text="Known EVE Accounts..." VerticalAlignment="Top"/>
                     <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Margin="5" VerticalAlignment="Stretch">
-                        <ListBox Name="listAccounts" HorizontalAlignment="Left" VerticalAlignment="Stretch" Width="362" ItemsSource="{Binding ElementName=mainWindow, Path=Accounts}" SelectionMode="Multiple">
+                        <ListBox Name="listAccounts" HorizontalAlignment="Left" VerticalAlignment="Stretch" Width="362" ItemsSource="{Binding ElementName=mainWindow, Path=Accounts}" SelectionMode="Multiple" ContextMenuOpening="listAccounts_ContextMenuOpening">
+                            <ListBox.ContextMenu>
+                                <ContextMenu>
+                                    <MenuItem Header="Set Password..." Click="menuSetPassword_Click" />
+                                </ContextMenu>
+                            </ListBox.ContextMenu>
                             <ListBox.ItemTemplate>
                                 <DataTemplate>
-                                    <StackPanel>
-                                        <TextBlock Text="{Binding Path=Username}" />
-                                    </StackPanel>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="18" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" FontFamily="Segoe MDL2 Assets" Text="{Binding Credential.Glyph}" Foreground="{Binding Credential.Brush}" ToolTip="{Binding Credential.Tooltip}" />
+                                        <TextBlock Grid.Column="1" Text="{Binding Path=Username}" Margin="4,0,0,0" />
+                                    </Grid>
                                 </DataTemplate>
                             </ListBox.ItemTemplate>
                         </ListBox>

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -60,7 +60,7 @@
 
                         <ScrollViewer Margin="5,0,0,0" Width="187" VerticalScrollBarVisibility="Auto">
                             <StackPanel>
-                                <CheckBox Name="checkSavePasswords" Content="Save passwords (securely)" Margin="0,3,0,0" Click="checkSavePasswords_Click" />
+                                <CheckBox Name="checkSavePasswords" Content="Save credentials (securely)" Margin="0,3,0,0" Click="checkSavePasswords_Click" />
                                 <CheckBox Name="checkUseRefreshTokens" Content="Use OAuth2 Refresh Tokens" Margin="0,3,0,0" IsChecked="{Binding ElementName=mainWindow, Path=UseRefreshTokens}">
                                     <CheckBox.ToolTip>
                                         <TextBlock TextWrapping="Wrap" Width="200">Use OAuth2 Refresh Tokens to log in, instead of username and passwords.</TextBlock>
@@ -178,7 +178,7 @@
                             </ListBox.ItemTemplate>
                         </ListBox>
                         <DockPanel  Margin="5,0,0,0" Width="187" Height="240">
-                            <CheckBox DockPanel.Dock="Top" x:Name="checkSaveCharacterPasswords" Content="Save passwords (securely)" Margin="0,3,0,0" Click="checkSavePasswords_Click" IsChecked="{Binding IsChecked, ElementName=checkUseRefreshTokens}" />
+                            <CheckBox DockPanel.Dock="Top" x:Name="checkSaveCharacterPasswords" Content="Save credentials (securely)" Margin="0,3,0,0" Click="checkSavePasswords_Click" IsChecked="{Binding IsChecked, ElementName=checkUseRefreshTokens}" />
                             <Button DockPanel.Dock="Top" x:Name="buttonAddCharacter" Content="Add Character" Click="buttonAddCharacter_Click" Margin="0,3,0,0" />
                             <Button DockPanel.Dock="Top" x:Name="buttonDeleteCharacter" Content="Delete Character(s)" Click="buttonDeleteCharacter_Click" Margin="0,3,0,0" VerticalAlignment="Top" >
                                 <Button.Style>

--- a/Windows/MainWindow.xaml
+++ b/Windows/MainWindow.xaml
@@ -57,6 +57,7 @@
                                     </CheckBox.ToolTip>
                                 </CheckBox>
                                 <Button Name="buttonAddAccount" Content="Add Account"  Margin="0,3,0,0" Click="buttonAddAccount_Click" />
+                                <Button Name="buttonImportFromLauncher" Content="Import From EVE Launcher" Margin="0,3,0,0" Click="buttonImportFromLauncher_Click" ToolTip="Imports OAuth2 refresh tokens from the official EVE Online Launcher's saved state." />
                                 <Button Name="buttonDelete" Content="Delete Account(s)" Click="buttonDeleteAccount_Click" Margin="0,3,0,0" >
                                     <Button.Style>
                                         <Style>

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -443,6 +443,19 @@ namespace ISBoxerEVELauncher.Windows
                 App.Settings.Store();
             }
         }
+        
+        public bool UseRefreshTokens
+        {
+            get
+            {
+                return App.Settings.UseRefreshTokens;
+            }
+            set
+            {
+                App.Settings.UseRefreshTokens = value;
+                App.Settings.Store();
+            }
+        }
 
         private void buttonBrowse_Click(object sender, RoutedEventArgs e)
         {
@@ -978,6 +991,25 @@ namespace ISBoxerEVELauncher.Windows
             foreach (EVECharacter toDelete in deleteCharacters)
             {
                 Characters.Remove(toDelete);
+            }
+        }
+
+        private void buttonClearTokens_Click(object sender, RoutedEventArgs e)
+        {
+            switch (MessageBox.Show(
+                        "Are you sure you want to clear stored refresh tokens for the selected accounts? This will require all accounts to re-authenticate the next time they are used.",
+                        "Wait! You are about to clear all stored refresh tokens!", MessageBoxButton.YesNo))
+            {
+                case MessageBoxResult.Yes:
+                    foreach (EVEAccount acct in listAccounts.SelectedItems)
+                    {
+                        acct.ClearRefreshToken();
+                    }
+
+                    App.Settings.Store();
+                    break;
+                default:
+                    return;
             }
         }
     }

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -627,7 +627,7 @@ namespace ISBoxerEVELauncher.Windows
 
             if (!App.Settings.UseRefreshTokens || !App.Settings.UseMasterKey)
             {
-                MessageBox.Show("To import refresh tokens, enable 'Save passwords (securely)' and 'Use OAuth2 Refresh Tokens' first. Imported tokens are encrypted with your Master Password.");
+                MessageBox.Show("To import refresh tokens, enable 'Save credentials (securely)' and 'Use OAuth2 Refresh Tokens' first. Imported tokens are encrypted with your Master Password.");
                 return;
             }
 
@@ -721,7 +721,7 @@ namespace ISBoxerEVELauncher.Windows
                 // clear master key
                 if (App.Settings.UseMasterKey)
                 {
-                    switch (MessageBox.Show("By un-checking this box, this launcher will immediately clear out all *saved* passwords. Do you wish to continue?", "Wait! You are about to lose any saved passwords!", MessageBoxButton.YesNo))
+                    switch (MessageBox.Show("By un-checking this box, this launcher will immediately clear out saved credentials protected by your Master Password. Do you wish to continue?", "Wait! You are about to lose saved credentials!", MessageBoxButton.YesNo))
                     {
                         case MessageBoxResult.Yes:
                             App.Settings.ClearPasswordMasterKey();

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -586,6 +586,41 @@ namespace ISBoxerEVELauncher.Windows
 
         }
 
+        private EVEAccount _contextMenuTargetAccount;
+
+        private void listAccounts_ContextMenuOpening(object sender, ContextMenuEventArgs e)
+        {
+            var element = e.OriginalSource as DependencyObject;
+            ListBoxItem container = null;
+            while (element != null && element != listAccounts)
+            {
+                container = element as ListBoxItem;
+                if (container != null) break;
+                element = System.Windows.Media.VisualTreeHelper.GetParent(element)
+                         ?? System.Windows.LogicalTreeHelper.GetParent(element);
+            }
+            if (container == null)
+            {
+                e.Handled = true;
+                _contextMenuTargetAccount = null;
+                return;
+            }
+            _contextMenuTargetAccount = container.DataContext as EVEAccount;
+        }
+
+        private void menuSetPassword_Click(object sender, RoutedEventArgs e)
+        {
+            e.Handled = true;
+            var account = _contextMenuTargetAccount;
+            if (account == null) return;
+            var el = new EVELogin(account, true) { Owner = this };
+            el.ShowDialog();
+            if (el.DialogResult.HasValue && el.DialogResult.Value)
+            {
+                App.Settings.Store();
+            }
+        }
+
         private void buttonImportFromLauncher_Click(object sender, RoutedEventArgs e)
         {
             e.Handled = true;

--- a/Windows/MainWindow.xaml.cs
+++ b/Windows/MainWindow.xaml.cs
@@ -586,6 +586,91 @@ namespace ISBoxerEVELauncher.Windows
 
         }
 
+        private void buttonImportFromLauncher_Click(object sender, RoutedEventArgs e)
+        {
+            e.Handled = true;
+
+            if (!App.Settings.UseRefreshTokens || !App.Settings.UseMasterKey)
+            {
+                MessageBox.Show("To import refresh tokens, enable 'Save passwords (securely)' and 'Use OAuth2 Refresh Tokens' first. Imported tokens are encrypted with your Master Password.");
+                return;
+            }
+
+            if (!EVELauncherStateReader.StateFileExists())
+            {
+                MessageBox.Show("EVE Launcher state not found. Make sure the official EVE Launcher is installed and you've signed into at least one account.");
+                return;
+            }
+
+            List<ImportCandidate> candidates;
+            try
+            {
+                candidates = EVELauncherStateReader.Read();
+            }
+            catch (System.Security.Cryptography.CryptographicException ex)
+            {
+                MessageBox.Show("Failed to decrypt EVE Launcher state. If you copied this profile from another Windows account, the encrypted key cannot be unwrapped on this machine.\n\n" + ex.Message);
+                return;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                MessageBox.Show("AES-GCM is not available on this Windows version. Importing from the EVE Launcher requires Windows 10 1809 or newer.");
+                return;
+            }
+            catch (System.IO.IOException ex)
+            {
+                MessageBox.Show("Failed to read EVE Launcher state: " + ex.Message);
+                return;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("EVE Launcher state appears to be in an unexpected format: " + ex.Message);
+                return;
+            }
+
+            if (candidates.Count == 0)
+            {
+                MessageBox.Show("No accounts with refresh tokens were found in EVE Launcher state.");
+                return;
+            }
+
+            var dlg = new ImportFromEVELauncherWindow(candidates, App.Settings.Accounts) { Owner = this };
+            dlg.ShowDialog();
+            if (!(dlg.DialogResult.HasValue && dlg.DialogResult.Value))
+                return;
+
+            int added = 0;
+            int updated = 0;
+            foreach (var c in dlg.SelectedCandidates)
+            {
+                var ss = new System.Security.SecureString();
+                foreach (char ch in c.RefreshToken)
+                    ss.AppendChar(ch);
+                ss.MakeReadOnly();
+
+                var existing = App.Settings.Accounts.FirstOrDefault(a => !string.IsNullOrEmpty(a.Username)
+                    && a.Username.Equals(c.Username, StringComparison.InvariantCultureIgnoreCase));
+
+                if (existing != null)
+                {
+                    existing.SecureTranquilityRefreshToken = ss;
+                    existing.EncryptTranquilityRefreshToken();
+                    updated++;
+                }
+                else
+                {
+                    var acct = new EVEAccount { Username = c.Username };
+                    acct.SecureTranquilityRefreshToken = ss;
+                    acct.EncryptTranquilityRefreshToken();
+                    App.Settings.Accounts.Add(acct);
+                    added++;
+                }
+            }
+
+            App.Settings.Store();
+            MessageBox.Show(string.Format("Import complete. {0} added, {1} updated.", added, updated));
+        }
+
         private void checkSavePasswords_Click(object sender, RoutedEventArgs e)
         {
             e.Handled = true;

--- a/Windows/MasterKeyEntryWindow.xaml
+++ b/Windows/MasterKeyEntryWindow.xaml
@@ -6,7 +6,7 @@
         <TextBlock DockPanel.Dock="Top" HorizontalAlignment="Center" Margin="0,5,0,0" TextWrapping="Wrap" FontWeight="Bold" Text="A Password Master Key is configured and protecting your EVE Accounts." VerticalAlignment="Top"/>
         <TextBlock DockPanel.Dock="Top" HorizontalAlignment="Center" Margin="0,5,0,0" TextWrapping="Wrap" Text="Please enter your current Master Password for ISBoxer EVE Launcher." VerticalAlignment="Top"/>
         <PasswordBox DockPanel.Dock="Top" Name="passwordMasterKey" Margin="5" VerticalAlignment="Top"/>
-        <TextBlock DockPanel.Dock="Top" HorizontalAlignment="Center" Margin="5,0,5,5" FontStyle="Italic" TextWrapping="Wrap" Text="If you've lost this password, you can perform a reset by un-checking 'Save passwords (secure)', and saved passwords will be discarded." VerticalAlignment="Top"/>
+        <TextBlock DockPanel.Dock="Top" HorizontalAlignment="Center" Margin="5,0,5,5" FontStyle="Italic" TextWrapping="Wrap" Text="If you've lost this password, you can perform a reset by un-checking 'Save credentials (secure)', and saved credentials will be discarded." VerticalAlignment="Top"/>
         <DockPanel DockPanel.Dock="Bottom" Margin="5,0,5,5">
             <Button DockPanel.Dock="Right" Name="buttonGo"  Content="Go" VerticalAlignment="Top" Width="75" Click="buttonGo_Click" IsDefault="True" />
             <Button DockPanel.Dock="Right" x:Name="buttonCancel" IsCancel="True"  Content="Cancel" HorizontalAlignment="Right" Margin="5,0,5,0" VerticalAlignment="Top" Width="75" Click="buttonCancel_Click" />

--- a/Windows/MasterKeyEntryWindow.xaml.cs
+++ b/Windows/MasterKeyEntryWindow.xaml.cs
@@ -27,7 +27,7 @@ namespace ISBoxerEVELauncher.Windows
 
         private void buttonCancel_Click(object sender, RoutedEventArgs e)
         {
-            MessageBox.Show("Master Password entry cancelled. If you wish to reset the Master Password and clear saved EVE Account passwords, un-check 'Save passwords (secure)'");
+            MessageBox.Show("Master Password entry cancelled. If you wish to reset the Master Password and clear saved EVE Account credentials, un-check 'Save credentials (secure)'");
             e.Handled = true;
             DialogResult = false;
             this.Close();


### PR DESCRIPTION
## What changed
- Fixed the current EVE SSO login flow.
- Added OAuth2 refresh token login and encrypted refresh token storage.
- Added import of Tranquility refresh tokens from the official EVE Launcher.
- Added a WebView2 manual login option for cases where the automatic login flow fails.
- Added account credential indicators, right-click Set Password, and Clear OAuth2 Refresh Tokens.
- Added login debug logging and updated the README / changelog.

## Notes
- Refresh tokens use the existing Master Password protection.
- The EVE Launcher import reads the official launcher's local state and requires Windows AES-GCM support.
- Debug logs can contain sensitive login data.

## Testing
Tested by me and volunteers in the ISBoxer Discord.